### PR TITLE
remove MEP leichtfried

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -3930,36 +3930,6 @@
         "website": null
     },
     {
-        "Member": [
-            "INTA",
-            "D-BR",
-            "DMER"
-        ],
-        "Substitute": [
-            "TRAN",
-            "DASE"
-        ],
-        "Vice-Chair": [
-            "DLAT"
-        ],
-        "country": "Austria",
-        "country_short": "at",
-        "email": "joerg.leichtfried@europarl.europa.eu",
-        "facebook": "https://www.facebook.com/joerg.leichtfried",
-        "fax_bxl": "+3222849436",
-        "fax_stg": "+33388179436",
-        "group": "Group of the Progressive Alliance of Socialists and Democrats in the European Parliament",
-        "group_short": "sd",
-        "id": "28251",
-        "image": "http://www.europarl.europa.eu/mepphoto/28251.jpg",
-        "name": "J\u00f6rg LEICHTFRIED",
-        "party": "Sozialdemokratische Partei \u00d6sterreichs",
-        "score": 0.3,
-        "twitter": "jleichtfried",
-        "url": "http://www.europarl.europa.eu/meps/en/28251/JORG_LEICHTFRIED_home.html",
-        "website": "http://www.joerg-leichtfried.at"
-    },
-    {
         "Chair": [
             "D-CN"
         ],


### PR DESCRIPTION
he is not a MEP anymore, source: https://twitter.com/jleichtfried/status/613449662381588480